### PR TITLE
Description formatting change

### DIFF
--- a/lib/trellochow.rb
+++ b/lib/trellochow.rb
@@ -53,9 +53,12 @@ module Trellochow
 
       card_description = %{
 # Spec
-----
 #{card_spec}
+
+----
+
 # Code
+
 ----
       }
 


### PR DESCRIPTION
Divider after the content, rather than heading. I think this formatting makes sections clearer.

## Old: 
![old](http://imgur.com/klUy5FP.png)

## New:
![new](http://imgur.com/WsvCPIp.png)